### PR TITLE
[#53] fix: img tag가 2번씩 쓰여지던 문제.

### DIFF
--- a/client/lib/styledComponent.tsx
+++ b/client/lib/styledComponent.tsx
@@ -244,7 +244,7 @@ function deleteNamelessPart(scssStrings: string[], prefix: string) {
   let i = 0;
   for (i = 0; i < scssStrings.length; i += 1) {
     if (isStart(scssStrings[i])) {
-      return { result: result + '}\n', index: i - 1 };
+      return { result: result + '}\n', index: i };
     } else if (isEnd(scssStrings[i])) {
       throw new Error(
         '[styledComponent] : Nameless Part에서 } 를 발견했습니다. 문제되는 SCSS 문자열 : ' +


### PR DESCRIPTION
## 구현한 내용은 무엇인가요?
> Issue에 등록된 Task를 참고하여 작성해주세요!
> 애니메이션이 중요하다면 gif로 첨부 부탁드립니다!

예상 시간 : 2분
걸린 시간 : 20분

issue 53 처럼 되는 문제를 해결했습니다.

문제 상황은 아래와 같습니다.

```javascript
export const LogoText = styled.h2`
  font-size: 40px;
  margin: 20px;
  img {
    width: 300px;
  }
`;
```
nameless 부분에서 다른 모든 파일에서는 한칸 띄우고 정의가 되어있었습니다. 그런데 문제가 되는 상황에서는 붙어서 정의가 되어있었습니다.

nameless를 parsing 한 뒤 index 처리에서 -1 을 해줬어서 문제가 됐었는데, 이전까진 모두 한 칸 띄우고 정의를 했었어서 문제가 없어 보이다가 이번에 발견되었습니다.

## 구현할 때 어려웠던 점은 있나요?
> 10분 이상 걸렸던 오류가 있다면 작성해주세요!

디버깅이 어려웠던 것 같습니다.

## 추가로 알아야 하는 사항이 있다면 작성해주세요!
> 추후 고쳤거나 Refactoring이 필요한 TODO 사항을 작성해주세요!

현재는 고쳐졌기 떄문에 어떻게 쓰셔도 좋습니다~!
