### PR TITLE
[BE] server url to dot env

### DIFF
--- a/client/constants/server_url.ts
+++ b/client/constants/server_url.ts
@@ -1,4 +1,4 @@
-export const SERVER_URL = 'http://localhost:3000';
-export const API_URL = 'http://localhost:3000/api';
+export const SERVER_URL = process.env.SERVER_URL;
+export const API_URL = process.env.SERVER_URL + '/api';
 export const BASE_URL = '/api/auth';
 export const GITHUB_URL = `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${process.env.SERVER_URL}/callback`;


### PR DESCRIPTION
## 구현한 내용은 무엇인가요?
> Issue에 등록된 Task를 참고하여 작성해주세요!
> 애니메이션이 중요하다면 gif로 첨부 부탁드립니다!

예상 시간 : 0.5 시간
걸린 시간 : 0.5 시간

서버에서도 성공 한 모습입니다.

![image](https://user-images.githubusercontent.com/20200204/130363384-1f9b8c9e-9c23-46b5-9c35-accc4e83c755.png)

* dotenv 를 서버 URL로 변경 + Production 환경에서는 woowa.store 로 redirect 해 주게 변경.
* 서버에서의 dotenv 에서 github login key 를 다른 것으로 변경 ( woowa.store 로 redirect 하는걸로 )

## 구현할 때 어려웠던 점은 있나요?
> 10분 이상 걸렸던 오류가 있다면 작성해주세요!

* 없습니다.

## 추가로 알아야 하는 사항이 있다면 작성해주세요!
> 추후 고쳤거나 Refactoring이 필요한 TODO 사항을 작성해주세요!

서버 배포시 유의사항입니다.
```shell
# git pull
yarn build
cp ~/.env ./.env
pm2 start ‘TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true ts-node ./server/index.ts’
```
